### PR TITLE
Modified Golang repository image_resource and added resource type for email

### DIFF
--- a/ci/demo-pipeline.yml
+++ b/ci/demo-pipeline.yml
@@ -15,6 +15,12 @@ resources:
       from: {{email-from}}
       to: [ {{email-to}} ]
 
+resource_types:
+  - name: email
+    type: docker-image
+    source:
+      repository: pcfseceng/email-resource
+
 jobs:
   - name: demo-email-an-artifact-sha
     plan:
@@ -29,5 +35,5 @@ jobs:
             output_body_file: generated-body
       - put: send-an-email
         params:
-          subject: demo-prep-sha-email/generated-subject
-          body: demo-prep-sha-email/generated-body
+          subject: email-out/generated-subject
+          body: email-out/generated-body

--- a/ci/demo-prep-sha-email.yml
+++ b/ci/demo-prep-sha-email.yml
@@ -1,7 +1,9 @@
 ---
 platform: linux
 
-image: docker:///golang#1.5
+image_resource:
+  type: docker-image
+  source: {repository: golang, tag: "1.5"}
 
 inputs:
   - name: email-resource-source


### PR DESCRIPTION
1) Added "**resource-type:email**" in demo-pipeline.yml.

2) Output directory was supposed to be "**email-out**" instead of "**demo-prep-sha-email**"  in demo-pipeline.yml

3) Timeout when pulling golang image using "**image**". So modified demo-prep-sha-email.yml to use "**image_resource**".
