### PR TITLE
providing ability to send email without userid/pwd if smtp permits this

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,22 @@ resources:
     from: build-system@example.com
     to: [ "dev-team@example.com", "product@example.net" ]
 ```
+
+An example source configuration is below supporting sending email when anonymous is permitted.
+```yaml
+resources:
+- name: send-an-email
+  type: email
+  source:
+    smtp:
+      host: smtp.example.com
+      port: "587" # this must be a string
+      anonymous: true
+    from: build-system@example.com
+    to: [ "dev-team@example.com", "product@example.net" ]
+```
 Note that `to` is an array, and that `port` is a string.
-If you're using `fly configure` with the `--load-vars-from` (`-l`) substitutions, every `{{ variable }}` 
+If you're using `fly configure` with the `--load-vars-from` (`-l`) substitutions, every `{{ variable }}`
 [automatically gets converted to a string](http://concourse.ci/fly-cli.html).
 But for literals you need to surround it with quotes.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ resource_types:
   - name: email
     type: docker-image
     source:
-      repository: pcfseceng/email-resource
+      repository: pivotalservices/concourse-email-resource
 ```
 
 Look at the [demo pipeline](https://github.com/pivotal-cf/email-resource/blob/master/ci/demo-pipeline.yml) for a complete example.

--- a/actions/out/main.go
+++ b/actions/out/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/smtp"
 	"os"
@@ -21,10 +22,11 @@ func main() {
 	var indata struct {
 		Source struct {
 			SMTP struct {
-				Host     string
-				Port     string
-				Username string
-				Password string
+				Host      string
+				Port      string
+				Username  string
+				Password  string
+				Anonymous bool `json:"anonymous"`
 			}
 			From string
 			To   []string
@@ -58,16 +60,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if indata.Source.SMTP.Username == "" {
-		fmt.Fprintf(os.Stderr, `missing required field "source.smtp.username"`)
-		os.Exit(1)
-	}
-
-	if indata.Source.SMTP.Password == "" {
-		fmt.Fprintf(os.Stderr, `missing required field "source.smtp.password"`)
-		os.Exit(1)
-	}
-
 	if indata.Source.From == "" {
 		fmt.Fprintf(os.Stderr, `missing required field "source.from"`)
 		os.Exit(1)
@@ -81,6 +73,18 @@ func main() {
 	if indata.Params.Subject == "" {
 		fmt.Fprintf(os.Stderr, `missing required field "params.subject"`)
 		os.Exit(1)
+	}
+
+	if indata.Source.SMTP.Anonymous == false {
+		if indata.Source.SMTP.Username == "" {
+			fmt.Fprintf(os.Stderr, `missing required field "source.smtp.username" if anonymous specify anonymous: true`)
+			os.Exit(1)
+		}
+
+		if indata.Source.SMTP.Password == "" {
+			fmt.Fprintf(os.Stderr, `missing required field "source.smtp.password" if anonymous specify anonymous: true`)
+			os.Exit(1)
+		}
 	}
 
 	readSource := func(sourcePath string) (string, error) {
@@ -154,18 +158,47 @@ func main() {
 		return
 	}
 
-	err = smtp.SendMail(
-		fmt.Sprintf("%s:%s", indata.Source.SMTP.Host, indata.Source.SMTP.Port),
-		smtp.PlainAuth(
-			"",
-			indata.Source.SMTP.Username,
-			indata.Source.SMTP.Password,
-			indata.Source.SMTP.Host,
-		),
-		indata.Source.From,
-		indata.Source.To,
-		messageData,
-	)
+	if indata.Source.SMTP.Anonymous {
+		var c *smtp.Client
+		var wc io.WriteCloser
+		c, err = smtp.Dial(fmt.Sprintf("%s:%s", indata.Source.SMTP.Host, indata.Source.SMTP.Port))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error Dialing: "+err.Error())
+			os.Exit(1)
+		}
+		defer c.Close()
+		c.Mail(indata.Source.From)
+
+		for _, toAddress := range indata.Source.To {
+			c.Rcpt(toAddress)
+		}
+		// Send the email body.
+		wc, err = c.Data()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error Getting writer context: "+err.Error())
+			os.Exit(1)
+		}
+		defer wc.Close()
+		_, err = wc.Write(messageData)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error Writing bytes: "+err.Error())
+			os.Exit(1)
+		}
+
+	} else {
+		err = smtp.SendMail(
+			fmt.Sprintf("%s:%s", indata.Source.SMTP.Host, indata.Source.SMTP.Port),
+			smtp.PlainAuth(
+				"",
+				indata.Source.SMTP.Username,
+				indata.Source.SMTP.Password,
+				indata.Source.SMTP.Host,
+			),
+			indata.Source.From,
+			indata.Source.To,
+			messageData,
+		)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to send an email using SMTP server %s on port %s: %v",
 			indata.Source.SMTP.Host, indata.Source.SMTP.Port, err)

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -26,10 +26,11 @@ var _ = Describe("Out", func() {
 	type inputStruct struct {
 		Source struct {
 			SMTP struct {
-				Host     string `json:"host"`
-				Port     string `json:"port"`
-				Username string `json:"username"`
-				Password string `json:"password"`
+				Host      string `json:"host"`
+				Port      string `json:"port"`
+				Username  string `json:"username"`
+				Password  string `json:"password"`
+				Anonymous bool   `json:"anonymous"`
 			} `json:"smtp"`
 			To   []string `json:"to"`
 			From string   `json:"from"`
@@ -328,7 +329,20 @@ Subject: some subject line
 
 			output, err := RunWithStdinAllowError(inputdata, "../bin/out", sourceRoot)
 			Expect(err).To(MatchError("exit status 1"))
-			Expect(output).To(Equal(`missing required field "source.smtp.username"`))
+			Expect(output).To(Equal(`missing required field "source.smtp.username" if anonymous specify anonymous: true`))
+		})
+	})
+
+	Context("when the 'source.smtp.username' is empty and Anonymous", func() {
+		It("should not error", func() {
+			inputs.Source.SMTP.Username = ""
+			inputs.Source.SMTP.Anonymous = true
+			inputBytes, err := json.Marshal(inputs)
+			Expect(err).NotTo(HaveOccurred())
+			inputdata = string(inputBytes)
+
+			_, err = RunWithStdinAllowError(inputdata, "../bin/out", sourceRoot)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
@@ -341,7 +355,20 @@ Subject: some subject line
 
 			output, err := RunWithStdinAllowError(inputdata, "../bin/out", sourceRoot)
 			Expect(err).To(MatchError("exit status 1"))
-			Expect(output).To(Equal(`missing required field "source.smtp.password"`))
+			Expect(output).To(Equal(`missing required field "source.smtp.password" if anonymous specify anonymous: true`))
+		})
+	})
+
+	Context("when the 'source.smtp.password' is empty and Anonymous", func() {
+		It("should not error", func() {
+			inputs.Source.SMTP.Password = ""
+			inputs.Source.SMTP.Anonymous = true
+			inputBytes, err := json.Marshal(inputs)
+			Expect(err).NotTo(HaveOccurred())
+			inputdata = string(inputBytes)
+
+			_, err = RunWithStdinAllowError(inputdata, "../bin/out", sourceRoot)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
Ability to leverage this concourse resource when SMTP server allows sending email without userid/pwd and doesn't require TLS.  This addresses the following issue (https://github.com/pivotal-cf/email-resource/issues/6) and is similar to other pull request but is backward compatible as introduces new source config option `anonymous: true/false` which defaults to false.  
