### PR TITLE
Providing ability to use concourse metadata from within params input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ resources:
       username: a-user
       password: my-password
     from: build-system@example.com
-    to: [ "dev-team@example.com", "product@example.net" ]
+    to: [ "dev-team@example.com", "product@example.net" ] #optional if `params.additional_recipient` is specified
 ```
 Note that `to` is an array, and that `port` is a string.
 If you're using `fly configure` with the `--load-vars-from` (`-l`) substitutions, every `{{ variable }}` 
@@ -46,13 +46,13 @@ This is an output-only resource, so `check` and `in` actions are no-ops.
 
 #### Parameters
 
-**NB: All parameters which are to be read from a file but begin with the literal `##` would be interpreted as a string and not a filepath**
 
-* `headers`: *Optional.* Path to plain text file containing additional mail headers or literal string if the value begins with `##`
-* `additional_recipient`: *Optional.* Path to plain text file containing additional recipient which could be determined at build time or literal string if the value begins with `##`. You can run a task before, which figures out the email of the person who committed last to a git repository (`git -C $source_path --no-pager show $(git -C $source_path rev-parse HEAD) -s --format='%ae' > output/email.txt`)
-* `subject`: *Required.* Path to plain text file containing the subject or literal string if the value begins with `##`
-* `body`: *Required.* Path to file containing the email body or literal string if the value begins with `##`
+* `headers`: *Optional.* Path to plain text file containing additional mail headers
+* `additional_recipient`: *Optional.* Path to plain text file containing additional recipient which could be determined at build time. You can run a task before, which figures out the email of the person who committed last to a git repository (`git -C $source_path --no-pager show $(git -C $source_path rev-parse HEAD) -s --format='%ae' > output/email.txt`)
+* `subject`: *Required.* Path to plain text file containing the subject
+* `body`: *Required.* Path to file containing the email body
 * `send_empty_body`: *Optional.* If true, send the email even if the body is empty (defaults to `false`).
+
 
 For example, a build plan might contain this:
 ```yaml
@@ -62,14 +62,15 @@ For example, a build plan might contain this:
       body: demo-prep-sha-email/generated-body
 ```
 
-Example build plan with string literals:
-```yaml
-  - put: send-an-email
-    params:
-      subject: ##Build failed in Concourse: $BUILD_PIPELINE_NAME #${BUILD_ID}
-      body: ##See ${ATC_EXTERNAL_URL}/builds/${BUILD_ID}
-      additional_recipient: demo-prep-sha-email/generated-email
-```
+You can use the values below in any of the source files to access the corresponding metadata made available by concourse, as documented [here](http://concourse.ci/implementing-resources.html)
+
+* `${BUILD_ID}`
+* `${BUILD_NAME}`
+* `${BUILD_JOB_NAME}`
+* `${BUILD_PIPELINE_NAME}`
+* `${ATC_EXTERNAL_URL}`
+
+For example `demo-prep-sha-email/generated-subject` could have content `Build ${BUILD_JOB_NAME} failed` which would result in the subject sent to be `Build demo-email-an-artifact-sha failed`
 
 #### HTML Email
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ This is an output-only resource, so `check` and `in` actions are no-ops.
 
 #### Parameters
 
-* `headers`: *Optional.* Path to plain text file containing additional mail headers
-* `subject`: *Required.* Path to plain text file containing the subject
-* `body`: *Required.* Path to file containing the email body.
+**NB: All parameters which are to be read from a file but begin with the literal `##` would be interpreted as a string and not a filepath**
+
+* `headers`: *Optional.* Path to plain text file containing additional mail headers or literal string if the value begins with `##`
+* `additional_recipient`: *Optional.* Path to plain text file containing additional recipient which could be determined at build time or literal string if the value begins with `##`. You can run a task before, which figures out the email of the person who committed last to a git repository (`git -C $source_path --no-pager show $(git -C $source_path rev-parse HEAD) -s --format='%ae' > output/email.txt`)
+* `subject`: *Required.* Path to plain text file containing the subject or literal string if the value begins with `##`
+* `body`: *Required.* Path to file containing the email body or literal string if the value begins with `##`
 * `send_empty_body`: *Optional.* If true, send the email even if the body is empty (defaults to `false`).
 
 For example, a build plan might contain this:
@@ -57,6 +60,15 @@ For example, a build plan might contain this:
     params:
       subject: demo-prep-sha-email/generated-subject
       body: demo-prep-sha-email/generated-body
+```
+
+Example build plan with string literals:
+```yaml
+  - put: send-an-email
+    params:
+      subject: ##Build failed in Concourse: $BUILD_PIPELINE_NAME #${BUILD_ID}
+      body: ##See ${ATC_EXTERNAL_URL}/builds/${BUILD_ID}
+      additional_recipient: demo-prep-sha-email/generated-email
 ```
 
 #### HTML Email

--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ This is an output-only resource, so `check` and `in` actions are no-ops.
 * `headers`: *Optional.* Path to plain text file containing additional mail headers
 * `additional_recipient`: *Optional.* Path to plain text file containing additional recipient which could be determined at build time. You can run a task before, which figures out the email of the person who committed last to a git repository (`git -C $source_path --no-pager show $(git -C $source_path rev-parse HEAD) -s --format='%ae' > output/email.txt`)
 * `subject`: *Required.* Path to plain text file containing the subject
-* `body`: *Required.* Path to file containing the email body
+* `body`: *Required.* Path to file containing the email body.
 * `send_empty_body`: *Optional.* If true, send the email even if the body is empty (defaults to `false`).
-
 
 For example, a build plan might contain this:
 ```yaml

--- a/actions/out/main.go
+++ b/actions/out/main.go
@@ -39,10 +39,10 @@ func main() {
 		}
 		Params struct {
 			Subject             string
-			AdditionalRecipient string `json:"additional_recipient"`
 			Body                string
 			SendEmptyBody       bool `json:"send_empty_body"`
 			Headers             string
+			AdditionalRecipient string `json:"additional_recipient"`
 		}
 	}
 
@@ -83,7 +83,7 @@ func main() {
 	}
 
 	if len(indata.Source.To) == 0 && len(indata.Params.AdditionalRecipient) == 0 {
-		fmt.Fprintf(os.Stderr, `missing required field "source.to" and "params.additional_recipient". Must specify at least one`)
+		fmt.Fprintf(os.Stderr, `missing required field "source.to" or "params.additional_recipient". Must specify at least one`)
 		os.Exit(1)
 	}
 
@@ -105,7 +105,6 @@ func main() {
 		}
 
 		bytes, err := ioutil.ReadFile(sourcePath)
-
 		return replaceTokens(string(bytes)), err
 	}
 

--- a/actions/out/main.go
+++ b/actions/out/main.go
@@ -145,6 +145,8 @@ func main() {
 	}
 
 	if len(additionalRecipient) > 0 {
+		additionalRecipient = strings.Trim(additionalRecipient, "\n")
+		additionalRecipient = strings.TrimSpace(additionalRecipient)
 		indata.Source.To = append(indata.Source.To, additionalRecipient)
 	}
 

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -36,10 +36,10 @@ var _ = Describe("Out", func() {
 		} `json:"source"`
 		Params struct {
 			Subject             string `json:"subject"`
-			AdditionalRecipient string `json:"additional_recipient"`
 			Body                string `json:"body"`
 			SendEmptyBody       bool   `json:"send_empty_body"`
 			Headers             string `json:"headers"`
+			AdditionalRecipient string `json:"additional_recipient"`
 		} `json:"params"`
 	}
 
@@ -349,7 +349,6 @@ Subject: some subject line
 		Context("When the additional_recipient field is not empty", func() {
 			It("should succed", func() {
 				inputs.Source.To = nil
-				//inputs.Params.AdditionalRecipient = "recipient+3@example.com"
 				inputBytes, err := json.Marshal(inputs)
 				Expect(err).NotTo(HaveOccurred())
 				inputdata = string(inputBytes)

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -342,7 +342,7 @@ Subject: some subject line
 
 				output, err := RunWithStdinAllowError(inputdata, "../bin/out", sourceRoot)
 				Expect(err).To(MatchError("exit status 1"))
-				Expect(output).To(Equal(`missing required field "source.to" and "params.additional_recipient". Must specify at least one`))
+				Expect(output).To(Equal(`missing required field "source.to" or "params.additional_recipient". Must specify at least one`))
 			})
 		})
 

--- a/tests/out_test.go
+++ b/tests/out_test.go
@@ -82,7 +82,7 @@ it has many lines
 even empty lines
 
 !`)
-		createSource(inputs.Params.AdditionalRecipient, "recipient+3@example.com")
+		createSource(inputs.Params.AdditionalRecipient, "recipient+3@example.com \n")
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
Hello

Started using your resource and made some changes to it and thought I should push it upstream
- ability to use concourse metadata in email text like ${BUILD_ID}, etc
- made source.to optional if params.additional_recipient is set, this gives you the ability to determine who to send the email to at build time from a git commit for example
