### PR TITLE
Add support for BCC

### DIFF
--- a/out/out.go
+++ b/out/out.go
@@ -129,6 +129,20 @@ func Execute(sourceRoot, version string, input []byte) (string, error) {
 		}
 	}
 
+	if indata.Params.Bcc != "" {
+		var bccList string
+		bccList, err = readSource(indata.Params.Bcc)
+		if err != nil {
+			return "", err
+		}
+		if len(bccList) > 0 {
+			bccListArray := strings.Split(bccList, ",")
+			for _, bccAddress := range bccListArray {
+				indata.Source.Bcc = append(indata.Source.Bcc, strings.TrimSpace(bccAddress))
+			}
+		}
+	}
+
 	var outdata Output
 	outdata.Version.Time = time.Now().UTC()
 	outdata.Metadata = []MetadataItem{
@@ -194,6 +208,11 @@ func Execute(sourceRoot, version string, input []byte) (string, error) {
 		return "", err
 	}
 	for _, addr := range indata.Source.To {
+		if err = c.Rcpt(addr); err != nil {
+			return "", err
+		}
+	}
+	for _, addr := range indata.Source.Bcc {
 		if err = c.Rcpt(addr); err != nil {
 			return "", err
 		}

--- a/out/types.go
+++ b/out/types.go
@@ -16,6 +16,7 @@ type Input struct {
 		}
 		From string
 		To   []string
+		Bcc  []string
 	}
 	Params struct {
 		Subject       string
@@ -26,6 +27,7 @@ type Input struct {
 		Headers       string
 		HeadersText   string `json:"headers_text"`
 		To            string `json:"to"`
+		Bcc           string `json:"bcc"`
 	}
 }
 


### PR DESCRIPTION
Added support for using the BCC field via SMTP since (to gmail at least) the BCC targets must be included in the RCPT TO part. 