### PR TITLE
Fix CC source parameter

### DIFF
--- a/out/out.go
+++ b/out/out.go
@@ -69,7 +69,7 @@ func Execute(sourceRoot, version string, input []byte) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "Error getting cc list:")
 	}
-	source.Cc = append(source.Bcc, ccArray...)
+	source.Cc = append(source.Cc, ccArray...)
 
 	bccArray, err := sliceFromTextOrFile(sourceRoot, params.BccText, params.Bcc)
 	if err != nil {


### PR DESCRIPTION
The `cc` parameter in the `source` configuration was ignored because it also used the `bcc`.