### PR TITLE
Skip recipient if it is an unknown instead of fail

### DIFF
--- a/out/sender.go
+++ b/out/sender.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/smtp"
+	"net/textproto"
 	"os"
 	"path/filepath"
 
@@ -102,6 +103,10 @@ func (s *Sender) Send(msg []byte) error {
 	}
 	for _, addr := range s.To {
 		if err = c.Rcpt(addr); err != nil {
+			if errCode, ok := err.(*textproto.Error); ok && errCode.Code == 550 {
+				s.logger.Printf("Skipping %s: %s\n", addr, err.Error())
+				continue
+			}
 			return errors.Wrap(err, "Error setting to:")
 		}
 	}


### PR DESCRIPTION
When user doesn't exists anymore on an smtp server we get:

```
v1.0.18 - Error during execute - Error setting to:: 550 5.1.1 <an.unkownuser@orange.com>: Recipient address rejected: User unknown
```

And the resource will stop sending. But it is more interesting to only notified that this recipient will be skipped instead of triggering error to continu sending.

This PR add this behaviour instead of the current behaviour.